### PR TITLE
Fix format string clippy warning in integration tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
+use anyhow::{Context, Result};
 use clap::Parser;
-use std::collections::HashMap;
-use std::process::Command;
-use std::path::PathBuf;
-use std::fs;
-use anyhow::{Result, Context};
 use git2::Repository;
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Mutex;
 use tokio::signal;
 
-use iz::{parse_key_val, substitute_variables, read_config};
+use iz::{parse_key_val, read_config, substitute_variables};
 
 static CLEANUP_STATE: Lazy<Mutex<Option<PathBuf>>> = Lazy::new(|| Mutex::new(None));
 
@@ -22,18 +22,18 @@ static CLEANUP_STATE: Lazy<Mutex<Option<PathBuf>>> = Lazy::new(|| Mutex::new(Non
 struct Cli {
     /// Git commit ID
     commit_id: String,
-    
+
     /// Command to execute
     command: String,
-    
+
     /// Keep temporary directory after execution
     #[arg(long)]
     keep: bool,
-    
+
     /// Temporary directory path (default: .iztemp)
     #[arg(long)]
     temp_dir: Option<String>,
-    
+
     /// Additional parameters (--key=value format)
     #[arg(long, value_parser = parse_key_val)]
     param: Vec<(String, String)>,
@@ -42,31 +42,33 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    
+
     println!("🔄 Starting iz CLI...");
-    
+
     let config = read_config().context("Failed to read izconfig.json")?;
-    
-    let command_template = config.commands.get(&cli.command)
+
+    let command_template = config
+        .commands
+        .get(&cli.command)
         .ok_or_else(|| anyhow::anyhow!("Command '{}' not found in izconfig.json", cli.command))?;
-    
+
     let params: HashMap<String, String> = cli.param.into_iter().collect();
     let final_command = substitute_variables(command_template, &params)?;
-    
+
     println!("🎯 Commit: {}", cli.commit_id);
     println!("📝 Command: {final_command}");
-    
+
     let should_keep = cli.keep || config.keep.unwrap_or(false);
     let base_temp_dir = determine_temp_dir(&cli.temp_dir, &config)?;
     let temp_path = create_unique_temp_dir(&base_temp_dir)?;
-    
+
     if !should_keep {
         let mut cleanup_state = CLEANUP_STATE.lock().unwrap();
         *cleanup_state = Some(temp_path.clone());
     }
-    
+
     println!("📁 Temporary directory: {}", temp_path.display());
-    
+
     let signal_handle = if !should_keep {
         Some(tokio::spawn(async {
             let _ = setup_signal_handler().await;
@@ -74,18 +76,18 @@ async fn main() -> Result<()> {
     } else {
         None
     };
-    
+
     checkout_commit_to_temp(&cli.commit_id, &temp_path).context("Failed to checkout commit")?;
-    
+
     println!("🚀 Executing command...");
     execute_command(&final_command, &temp_path).context("Failed to execute command")?;
-    
+
     cleanup_temp_directory(&temp_path, should_keep);
-    
+
     if let Some(handle) = signal_handle {
         handle.abort();
     }
-    
+
     println!("✅ Operation completed!");
     Ok(())
 }
@@ -93,28 +95,28 @@ async fn main() -> Result<()> {
 fn checkout_commit_to_temp(commit_id: &str, temp_path: &std::path::Path) -> Result<()> {
     let repo = Repository::open(std::env::current_dir()?)
         .context("Git repository not found - this directory is not a git repository")?;
-    
-    let object = repo.revparse_single(commit_id)
+
+    let object = repo
+        .revparse_single(commit_id)
         .context("Commit not found - invalid commit ID")?;
-    
-    let commit = object.peel_to_commit()
+
+    let commit = object
+        .peel_to_commit()
         .context("Given reference does not point to a commit")?;
-    
-    let tree = commit.tree()
-        .context("Failed to get commit tree")?;
-    
+
+    let tree = commit.tree().context("Failed to get commit tree")?;
+
     // Pre-create directory structure to avoid git2 checkout issues
-    create_directory_structure(&tree, temp_path)
-        .context("Failed to create directory structure")?;
-    
+    create_directory_structure(&tree, temp_path).context("Failed to create directory structure")?;
+
     let mut checkout_builder = git2::build::CheckoutBuilder::new();
     checkout_builder.target_dir(temp_path);
     checkout_builder.force();
     checkout_builder.recreate_missing(true);
-    
+
     repo.checkout_tree(tree.as_object(), Some(&mut checkout_builder))
         .context("Failed to extract files")?;
-    
+
     Ok(())
 }
 
@@ -123,12 +125,16 @@ fn create_directory_structure(tree: &git2::Tree, base_path: &std::path::Path) ->
         if let Some(git2::ObjectType::Tree) = entry.kind() {
             let dir_path = base_path.join(root).join(entry.name().unwrap_or(""));
             if let Err(e) = fs::create_dir_all(&dir_path) {
-                eprintln!("Warning: Failed to create directory {}: {}", dir_path.display(), e);
+                eprintln!(
+                    "Warning: Failed to create directory {}: {}",
+                    dir_path.display(),
+                    e
+                );
             }
         }
         git2::TreeWalkResult::Ok
     })?;
-    
+
     Ok(())
 }
 
@@ -137,38 +143,40 @@ fn execute_command(command: &str, working_dir: &std::path::Path) -> Result<()> {
     if parts.is_empty() {
         return Err(anyhow::anyhow!("Empty command"));
     }
-    
+
     let mut cmd = Command::new(parts[0]);
     if parts.len() > 1 {
         cmd.args(&parts[1..]);
     }
-    
+
     cmd.current_dir(working_dir);
-    
-    let output = cmd.output()
-        .context("Failed to execute command")?;
-    
+
+    let output = cmd.output().context("Failed to execute command")?;
+
     if !output.stdout.is_empty() {
         println!("📄 Output:");
         println!("{}", String::from_utf8_lossy(&output.stdout));
     }
-    
+
     if !output.stderr.is_empty() {
         eprintln!("⚠️  Error output:");
         eprintln!("{}", String::from_utf8_lossy(&output.stderr));
     }
-    
+
     if !output.status.success() {
-        return Err(anyhow::anyhow!("Command failed with status: {}", output.status));
+        return Err(anyhow::anyhow!(
+            "Command failed with status: {}",
+            output.status
+        ));
     }
-    
+
     Ok(())
 }
 
 async fn setup_signal_handler() -> Result<()> {
     let mut sigint = signal::unix::signal(signal::unix::SignalKind::interrupt())?;
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())?;
-    
+
     tokio::select! {
         _ = sigint.recv() => {
             println!("\n🛑 Received SIGINT (Ctrl+C)");
@@ -199,7 +207,7 @@ fn cleanup_temp_directory(temp_path: &PathBuf, should_keep: bool) {
     if let Ok(mut cleanup_state) = CLEANUP_STATE.lock() {
         *cleanup_state = None;
     }
-    
+
     if should_keep {
         println!("💾 Temporary directory preserved: {}", temp_path.display());
     } else if let Err(e) = fs::remove_dir_all(temp_path) {
@@ -213,39 +221,46 @@ fn determine_temp_dir(cli_temp_dir: &Option<String>, config: &iz::IzConfig) -> R
     if let Some(temp_dir) = cli_temp_dir {
         return Ok(PathBuf::from(temp_dir));
     }
-    
+
     if let Ok(env_temp_dir) = std::env::var("IZTEMP") {
         return Ok(PathBuf::from(env_temp_dir));
     }
-    
+
     if let Some(config_temp_dir) = &config.temp_dir {
         return Ok(PathBuf::from(config_temp_dir));
     }
-    
-    let current_dir = std::env::current_dir()
-        .context("Failed to get current directory")?;
-    
+
+    let current_dir = std::env::current_dir().context("Failed to get current directory")?;
+
     Ok(current_dir.join(".iztemp"))
 }
 
 fn create_unique_temp_dir(base_temp_dir: &PathBuf) -> Result<PathBuf> {
     if !base_temp_dir.exists() {
-        fs::create_dir_all(base_temp_dir)
-            .with_context(|| format!("Failed to create temp directory: {}", base_temp_dir.display()))?;
+        fs::create_dir_all(base_temp_dir).with_context(|| {
+            format!(
+                "Failed to create temp directory: {}",
+                base_temp_dir.display()
+            )
+        })?;
     }
-    
+
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis();
-    
+
     let random_id: u32 = rand::random();
     let unique_name = format!("iz-{timestamp}-{random_id:x}");
-    
+
     let temp_path = base_temp_dir.join(unique_name);
-    
-    fs::create_dir_all(&temp_path)
-        .with_context(|| format!("Failed to create temporary directory: {}", temp_path.display()))?;
-    
+
+    fs::create_dir_all(&temp_path).with_context(|| {
+        format!(
+            "Failed to create temporary directory: {}",
+            temp_path.display()
+        )
+    })?;
+
     Ok(temp_path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Mutex;
+#[cfg(unix)]
 use tokio::signal;
 
 use iz::{parse_key_val, read_config, substitute_variables};
@@ -173,6 +174,7 @@ fn execute_command(command: &str, working_dir: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 async fn setup_signal_handler() -> Result<()> {
     let mut sigint = signal::unix::signal(signal::unix::SignalKind::interrupt())?;
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())?;
@@ -189,6 +191,14 @@ async fn setup_signal_handler() -> Result<()> {
             std::process::exit(143);
         }
     }
+}
+
+#[cfg(windows)]
+async fn setup_signal_handler() -> Result<()> {
+    tokio::signal::ctrl_c().await?;
+    println!("\n🛑 Received Ctrl+C");
+    perform_cleanup();
+    std::process::exit(130);
 }
 
 fn perform_cleanup() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -57,13 +57,16 @@ fn get_iz_binary_path() -> String {
     use std::env;
 
     let current_dir = env::current_dir().expect("Failed to get current directory");
+    
+    // Cross-platform executable name (adds .exe on Windows)
+    let binary_name = format!("iz{}", std::env::consts::EXE_SUFFIX);
 
-    let debug_path = current_dir.join("target/debug/iz");
+    let debug_path = current_dir.join("target/debug").join(&binary_name);
     if debug_path.exists() {
         return debug_path.to_string_lossy().to_string();
     }
 
-    let release_path = current_dir.join("target/release/iz");
+    let release_path = current_dir.join("target/release").join(&binary_name);
     if release_path.exists() {
         return release_path.to_string_lossy().to_string();
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -57,7 +57,7 @@ fn get_iz_binary_path() -> String {
     use std::env;
 
     let current_dir = env::current_dir().expect("Failed to get current directory");
-    
+
     // Cross-platform executable name (adds .exe on Windows)
     let binary_name = format!("iz{}", std::env::consts::EXE_SUFFIX);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,25 +1,25 @@
-use std::process::Command;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::env;
+use std::process::Command;
 
 fn create_test_git_repo_with_config(commands: &[(&str, &str)]) -> PathBuf {
     let temp_dir = env::temp_dir().join(format!("iz-integration-test-{}", rand::random::<u32>()));
     fs::create_dir_all(&temp_dir).unwrap();
     let repo_path = &temp_dir;
-    
+
     Command::new("git")
         .args(["init"])
         .current_dir(repo_path)
         .output()
         .expect("Git init failed");
-    
+
     Command::new("git")
         .args(["config", "user.email", "test@example.com"])
         .current_dir(repo_path)
         .output()
         .expect("Git config email failed");
-        
+
     Command::new("git")
         .args(["config", "user.name", "Test User"])
         .current_dir(repo_path)
@@ -34,46 +34,46 @@ fn create_test_git_repo_with_config(commands: &[(&str, &str)]) -> PathBuf {
         config_content.push('\n');
     }
     config_content.push_str("  }\n}");
-    
+
     fs::write(repo_path.join("izconfig.json"), config_content).unwrap();
     fs::write(repo_path.join("test.txt"), "Test content").unwrap();
-    
+
     Command::new("git")
         .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .expect("Git add failed");
-        
+
     Command::new("git")
         .args(["commit", "-m", "Test commit"])
         .current_dir(repo_path)
         .output()
         .expect("Git commit failed");
-    
+
     temp_dir
 }
 
 fn get_iz_binary_path() -> String {
     use std::env;
-    
+
     let current_dir = env::current_dir().expect("Failed to get current directory");
-    
+
     let debug_path = current_dir.join("target/debug/iz");
     if debug_path.exists() {
         return debug_path.to_string_lossy().to_string();
     }
-    
+
     let release_path = current_dir.join("target/release/iz");
     if release_path.exists() {
         return release_path.to_string_lossy().to_string();
     }
-    
+
     if let Ok(binary_path) = env::var("CARGO_BIN_EXE_iz") {
         if Path::new(&binary_path).exists() {
             return binary_path;
         }
     }
-    
+
     panic!("iz CLI binary not found. Run 'cargo build' first.");
 }
 
@@ -83,17 +83,21 @@ fn test_iz_cli_basic_command() {
         ("hello", "echo 'Hello from test project!'"),
         ("pwd", "pwd"),
     ]);
-    
+
     let iz_binary = get_iz_binary_path();
-    
+
     let output = Command::new(&iz_binary)
         .args(["HEAD", "hello"])
         .current_dir(&temp_repo)
         .output()
         .expect("Failed to run iz CLI");
-    
-    assert!(output.status.success(), "iz CLI failed: {}", String::from_utf8_lossy(&output.stderr));
-    
+
+    assert!(
+        output.status.success(),
+        "iz CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Hello from test project!"));
     assert!(stdout.contains("✅ Operation completed!"));
@@ -101,65 +105,66 @@ fn test_iz_cli_basic_command() {
 
 #[test]
 fn test_iz_cli_with_parameters() {
-    let temp_repo = create_test_git_repo_with_config(&[
-        ("greet", "echo 'Hello #{name}!'"),
-    ]);
-    
+    let temp_repo = create_test_git_repo_with_config(&[("greet", "echo 'Hello #{name}!'")]);
+
     let iz_binary = get_iz_binary_path();
-    
+
     let output = Command::new(&iz_binary)
         .args(["HEAD", "greet", "--param", "name=Integration"])
         .current_dir(&temp_repo)
         .output()
         .expect("Failed to run iz CLI");
-    
-    assert!(output.status.success(), "iz CLI failed: {}", String::from_utf8_lossy(&output.stderr));
-    
+
+    assert!(
+        output.status.success(),
+        "iz CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Hello Integration!"));
 }
 
 #[test]
 fn test_iz_cli_missing_config() {
-    let temp_dir = env::temp_dir().join(format!("iz-test-missing-config-{}", rand::random::<u32>()));
+    let temp_dir =
+        env::temp_dir().join(format!("iz-test-missing-config-{}", rand::random::<u32>()));
     fs::create_dir_all(&temp_dir).unwrap();
-    
+
     Command::new("git")
         .args(["init"])
         .current_dir(&temp_dir)
         .output()
         .expect("Git init failed");
-    
+
     let iz_binary = get_iz_binary_path();
-    
+
     let output = Command::new(&iz_binary)
         .args(["HEAD", "test"])
         .current_dir(&temp_dir)
         .output()
         .expect("Failed to run iz CLI");
-    
+
     assert!(!output.status.success(), "iz CLI should have failed");
-    
+
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("izconfig.json not found"));
 }
 
 #[test]
 fn test_iz_cli_missing_command() {
-    let temp_repo = create_test_git_repo_with_config(&[
-        ("run", "echo 'run command'"),
-    ]);
-    
+    let temp_repo = create_test_git_repo_with_config(&[("run", "echo 'run command'")]);
+
     let iz_binary = get_iz_binary_path();
-    
+
     let output = Command::new(&iz_binary)
         .args(["HEAD", "nonexistent"])
         .current_dir(&temp_repo)
         .output()
         .expect("Failed to run iz CLI");
-    
+
     assert!(!output.status.success(), "iz CLI should have failed");
-    
+
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("nonexistent") && stderr.contains("not found"));
 }
@@ -167,14 +172,14 @@ fn test_iz_cli_missing_command() {
 #[test]
 fn test_iz_cli_help() {
     let iz_binary = get_iz_binary_path();
-    
+
     let output = Command::new(&iz_binary)
         .args(["--help"])
         .output()
         .expect("Failed to run iz CLI help");
-    
+
     assert!(output.status.success(), "iz CLI help failed");
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("CLI tool for testing Git commits in temporary directories"));
     assert!(stdout.contains("Usage:"));
@@ -182,20 +187,18 @@ fn test_iz_cli_help() {
 
 #[test]
 fn test_iz_cli_missing_parameter() {
-    let temp_repo = create_test_git_repo_with_config(&[
-        ("greet", "echo 'Hello #{name}!'"),
-    ]);
-    
+    let temp_repo = create_test_git_repo_with_config(&[("greet", "echo 'Hello #{name}!'")]);
+
     let iz_binary = get_iz_binary_path();
-    
+
     let output = Command::new(&iz_binary)
         .args(["HEAD", "greet"])
         .current_dir(&temp_repo)
         .output()
         .expect("Failed to run iz CLI");
-    
+
     assert!(!output.status.success(), "iz CLI should have failed");
-    
+
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Required parameter not found: name"));
-} 
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27,7 +27,7 @@ fn create_test_git_repo_with_config(commands: &[(&str, &str)]) -> PathBuf {
         .expect("Git config name failed");
     let mut config_content = String::from("{\n  \"commands\": {\n");
     for (i, (key, value)) in commands.iter().enumerate() {
-        config_content.push_str(&format!("    \"{}\": \"{}\"", key, value));
+        config_content.push_str(&format!("    \"{key}\": \"{value}\""));
         if i < commands.len() - 1 {
             config_content.push(',');
         }


### PR DESCRIPTION
- Update format! macro to use inline variables in config generation
- Resolves clippy::uninlined_format_args warning
- Ensures GitHub Actions CI passes without clippy errors